### PR TITLE
既存APIの修正②とrubocopの規制緩和

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -22,9 +22,9 @@ module Api::V1
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
-    def destory
-      article = current_user.article.find(params[:id])
-      article.destory!
+    def destroy
+      article = current_user.articles.find(params[:id])
+      article.destroy!
     end
 
     private

--- a/config/database.yml.ci
+++ b/config/database.yml.ci
@@ -1,8 +1,8 @@
 test:
-  adapter: postgresql
+  adapter: mysql
   encoding: unicode
   pool: 5
   database: daily-report-api_test
-  username: postgres
-  password: postgres
+  username: mysql
+  password: mysql
   host: localhost

--- a/config/database.yml.ci
+++ b/config/database.yml.ci
@@ -1,8 +1,8 @@
 test:
-  adapter: mysql
+  adapter: mysql2
   encoding: unicode
   pool: 5
   database: daily-report-api_test
-  username: mysql
-  password: mysql
+  username: mysql2
+  password: mysql2
   host: localhost

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -42,13 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  config.headers_names = {
-    "access-token":  "access-token",
-    "client"      :  "client",
-    "expiry"      :  "expiry",
-    "uid"         :  "uid",
-    "token-type"  :  "token-type"
-  }
+  config.headers_names = { 'access-token': "access-token",
+                           client: "client",
+                           expiry: "expiry",
+                           uid: "uid",
+                           'token-type': "token-type" }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
-        registrations: "api/v1/auth/registrations"
+        registrations: "api/v1/auth/registrations",
       }
       resources :articles
     end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -47,6 +47,7 @@ RSpec/InstanceVariable:
 # パフォーマンスの問題さえ無ければ 1 example 1 assertion にしておく方が
 # 読みやすいテストになりやすいので、そこはレビューで担保していく必要がある。
 RSpec/MultipleExpectations:
+  Max: 8
   AggregateFailuresByDefault: false
   #公式ドキュメント見る
 

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -42,12 +42,12 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "P0ST/articles" do
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     context "userテーブルの一番初めのユーザー" do
       let(:params) { { article: attributes_for(:article) } }
       let(:current_user) { create(:user) }
-      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+      let(:headers) { current_user.create_new_auth_token }
 
       it "記事のレコードが1つ作成される" do
         expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
@@ -60,11 +60,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "PATCH /api/v1/articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params) }
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token }
 
     context "自分の記事のレコードを更新しようとするとき" do
       let(:article) { create(:article, user: current_user) }
@@ -88,14 +88,14 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "DELETE /api/v1/article/:id" do
-    subject { delete(api_v1_article_path(article_id)) }
+    subject { delete(api_v1_article_path(article_id), headers: headers) }
 
     let(:current_user) { create(:user) }
     let(:article_id) { article.id }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token }
 
     context "自分の記事を削除しようとするとき" do
-      let(:article) { create(:article, user: current_user) }
+      let!(:article) { create(:article, user: current_user) }
 
       it "その記事が削除される" do
         expect { subject }.to change { Article.count }.by(-1)

--- a/spec/requests/api/v1/auth/registrations_request_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_request_spec.rb
@@ -3,8 +3,10 @@ require "rails_helper"
 RSpec.describe "Api/V1::Auth::Registrations", type: :request do
   describe "POST /v1/auth" do
     subject { post(api_v1_user_registration_path, params: params) }
+
     context "ユーザーの情報がすべて入力されている" do
       let(:params) { attributes_for(:user) }
+
       it "新規登録が出来る" do
         expect { subject }.to change { User.count }.by(1)
         expect(response).to have_http_status(:ok)

--- a/spec/requests/sessions_request_spec.rb
+++ b/spec/requests/sessions_request_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "api/v1::auth::Sessions", type: :request do
         expect(response).to have_http_status(:ok)
       end
     end
+    
     context "emailが一致しない" do
       let(:params) { attributes_for(:user, email: "foo") }
 


### PR DESCRIPTION
【既存APIの修正】
・stubを使用していた箇所を修正
・headerを送信情報に含める

【rubocopの規制緩和】
・expectを8個まで緩和するよう修正